### PR TITLE
Hklem patch 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ requires-python = ">=3.11"
 # Declare any run-time dependencies that should be installed with the package.
 dependencies = [
     "importlib_resources",
+    "scipy=1.12",
     "MDAnalysis",
     "jupyterlab", #not super necessary, but helpful to follow along with examples
     "PyYAML", #aqme dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,16 +18,16 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.11, <=3.13.7"
 # Declare any run-time dependencies that should be installed with the package.
 dependencies = [
     "importlib_resources",
-    "scipy == 1.12",
+    "scipy",
     "MDAnalysis",
     "jupyterlab", #not super necessary, but helpful to follow along with examples
     "PyYAML", #aqme dependency
     #"aqme", #bc lots of dependencies
-    "rdkit-pypi", # dependency of aqme but doesn't get installed with pip install aqme
+    "rdkit", # dependency of aqme but doesn't get installed with pip install aqme
     "openbabel-wheel" #this works! And you don't have to add conda install -c conda-forge openbabel to config.yml, which makes testing faster (by like 30%)
     #"openbabel" #doesn't work to install this way... need to do conda install -c conda-forge openbabel in config.yml
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.11"
 # Declare any run-time dependencies that should be installed with the package.
 dependencies = [
     "importlib_resources",
-    "scipy=1.12",
+    "scipy == 1.12",
     "MDAnalysis",
     "jupyterlab", #not super necessary, but helpful to follow along with examples
     "PyYAML", #aqme dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ QMzyme = [
 
 [tool.versioningit]
 #default-version = "1+unknown"
-default-version = "0.0.7.dev0"
+default-version = "0.0.8.dev0"
 
 [tool.versioningit.format]
 #distance = "{base_version}+{distance}.{vcs}{rev}"
@@ -94,7 +94,7 @@ distance-dirty = "{tag}.post{distance}"
 method = "git"  # <- The method name
 # Parameters to pass to the method:
 match = ["*"]
-default-tag = "0.0.7.dev0"
+default-tag = "0.0.8.dev0"
 
 [tool.versioningit.write]
 file = "QMzyme/_version.py"


### PR DESCRIPTION
## Description
Updated dependencies to be compatible with newer Python versions, however python>3.14 has conflicts with mdanalysis install. Also updated rdkit install (used to be rdkit-pypi, but now it is just rdkit). 

## Todos
  - [ ] Look out for updates to mdanalysis to resolve issues with python>3.14
 

## Status
- [ ] Ready to go