### PR TITLE
Update dependencies and update version to 0.0.8.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ QMzyme = [
 
 [tool.versioningit]
 #default-version = "1+unknown"
-default-version = "0.0.7.dev0"
+default-version = "0.0.8.dev0"
 
 [tool.versioningit.format]
 #distance = "{base_version}+{distance}.{vcs}{rev}"


### PR DESCRIPTION
## Description
Updated dependencies to be compatible with newer Python versions,
however python>3.14 has conflicts with mdanalysis install. Also updated
rdkit install (used to be rdkit-pypi, but now it is just rdkit).

## Todos
- [x] Look out for updates to mdanalysis to resolve issues with
python>3.14
 

## Status
- [x] Ready to go