### PR TITLE
Modify requires-python to allow 3.11 and above

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.11, <=3.13.7"
+requires-python = ">=3.11"
 # Declare any run-time dependencies that should be installed with the package.
 dependencies = [
     "MDAnalysis",


### PR DESCRIPTION
Updated Python version requirement to allow 3.11 and above.
